### PR TITLE
Optional authFields for JWT payload.

### DIFF
--- a/src/guards.ts
+++ b/src/guards.ts
@@ -1,7 +1,7 @@
 import { Router, Handler } from 'express'
 import * as jwt from 'jsonwebtoken'
 import * as jsonServer from 'json-server'
-import { stringify } from 'querystring'
+import { stringify, ParsedUrlQueryInput } from 'querystring'
 import { JWT_SECRET_KEY } from './constants'
 import { bodyParsingHandler, errorHandler, goNext } from './shared-middlewares'
 
@@ -66,7 +66,7 @@ const privateOnly: Handler = (req, res, next) => {
 		}
 
 		// TODO: handle query params instead of removing them
-		const path = req.url.replace(`?${stringify(req.query)}`, '')
+		const path = req.url.replace(`?${stringify(req.query as ParsedUrlQueryInput)}`, '')
 		const [, mod, resource, id] = path.split('/')
 
 		// Creation and replacement


### PR DESCRIPTION
A project that I'm currently working on for school uses this library (so thank you for that).

However, we needed more data in the JWT payload (specifically a role). So I added some code to account for that.

Putting it simply, if you want a field to be sent in the JWT payload, add it to the `authFields` when creating the user, like so:
```
{
    "email": "example@example.com",
    "password": "password",
    "role": "admin",
    "age": 28,
    "authFields": ["role", "age"]
}
```

The `accessToken` returned will contain the email, sub (id), and any other fields that are in the authFields array.
And as a bonus, its retroactive. So any existing users in the db.json that you would like the JWT payload to return more fields on, just add the authFields array to it, and it'll work.
